### PR TITLE
Updates to Campaign Accessors

### DIFF
--- a/RockWeb/Plugins/church_ccv/PersonalizationEngine/DashboardCenterCard.ascx.cs
+++ b/RockWeb/Plugins/church_ccv/PersonalizationEngine/DashboardCenterCard.ascx.cs
@@ -53,13 +53,19 @@ namespace RockWeb.Plugins.church_ccv.PersonalizationEngine
         protected override void OnLoad( EventArgs e )
         {
             base.OnLoad( e );
+
+            Campaign campaignForCard = null;
             
             // first try to get a relevant campaign for this person
-            var campaignForCard = PersonalizationEngineUtil.GetRelevantCampaign( new Campaign.CampaignType[] { Campaign.CampaignType.WebsiteCard }, CurrentPerson.Id );
-            if ( campaignForCard == null )
+            var campaignList = PersonalizationEngineUtil.GetRelevantCampaign( new Campaign.CampaignType[] { Campaign.CampaignType.WebsiteCard }, CurrentPerson.Id );
+            if( campaignList.Count > 0 )
+            {
+                campaignForCard = campaignList[0];
+            }
+            else
             {
                 // if there's no relevant campaign, get all the "default" campaigns, and take the first one.
-                var defaultCampaigns = PersonalizationEngineUtil.GetDefaultCampaigns( new Campaign.CampaignType[] { Campaign.CampaignType.WebsiteCard } );
+                var defaultCampaigns = PersonalizationEngineUtil.GetDefaultCampaign( new Campaign.CampaignType[] { Campaign.CampaignType.WebsiteCard } );
                 campaignForCard = defaultCampaigns[ 0 ];
             }
 

--- a/church.ccv.PersonalizationEngine/Rest/PersonalizationEngineController.cs
+++ b/church.ccv.PersonalizationEngine/Rest/PersonalizationEngineController.cs
@@ -2,6 +2,7 @@
 using Newtonsoft.Json;
 using Rock.Rest.Filters;
 using System;
+using System.Collections.Generic;
 using System.Net.Http;
 using System.Text;
 using static church.ccv.PersonalizationEngine.Model.Campaign;
@@ -11,24 +12,25 @@ namespace church.ccv.PersonalizationEngine.Rest
     public class PersonalizationEngineController : Rock.Rest.ApiControllerBase
     {
         [System.Web.Http.HttpGet]
+        [System.Web.Http.Route( "api/PersonalizationEngine/Campaign" )]
         [System.Web.Http.Route( "api/PersonalizationEngine/RelevantCampaign" )]
         [Authenticate, Secured]
-        public HttpResponseMessage GetRelevantCampaign( string campaignTypeList, int personId )
+        public HttpResponseMessage GetCampaign( string campaignTypeList, int personId, int numCampaigns = 1 )
         {
             // convert the strings to enum
             CampaignType[] campaignTypeEnumList = StringToEnum( campaignTypeList );
 
             // now request the relevant campaign for the person
-            var campaignResult = PersonalizationEngineUtil.GetRelevantCampaign( campaignTypeEnumList, personId );
+            List<Model.Campaign> campaignResults = PersonalizationEngineUtil.GetRelevantCampaign( campaignTypeEnumList, personId, numCampaigns );
 
             // and if nothing was found, take a default
-            if( campaignResult == null )
+            if ( campaignResults.Count == 0 )
             {
-                var defaultCampaigns = PersonalizationEngineUtil.GetDefaultCampaigns( campaignTypeEnumList );
-                campaignResult = defaultCampaigns[ 0 ];
+                var defaultCampaigns = PersonalizationEngineUtil.GetDefaultCampaign( campaignTypeEnumList );
+                campaignResults.Add( defaultCampaigns[ 0 ] );
             }
 
-            StringContent restContent = new StringContent( JsonConvert.SerializeObject( campaignResult ), Encoding.UTF8, "application/json" );
+            StringContent restContent = new StringContent( JsonConvert.SerializeObject( campaignResults ), Encoding.UTF8, "application/json" );
             return new HttpResponseMessage()
             {
                 Content = restContent
@@ -36,18 +38,18 @@ namespace church.ccv.PersonalizationEngine.Rest
         }
 
         [System.Web.Http.HttpGet]
+        [System.Web.Http.Route( "api/PersonalizationEngine/Campaign" )]
         [System.Web.Http.Route( "api/PersonalizationEngine/DefaultCampaign" )]
         [Authenticate, Secured]
-        public HttpResponseMessage GetDefaultCampaign( string campaignTypeList )
+        public HttpResponseMessage GetDefaultCampaign( string campaignTypeList, int numCampaigns = 1 )
         {
             // convert the strings to enum
             CampaignType[] campaignTypeEnumList = StringToEnum( campaignTypeList );
 
             // now grab a default campaign
-            var defaultCampaigns = PersonalizationEngineUtil.GetDefaultCampaigns( campaignTypeEnumList );
-            var campaignResult = defaultCampaigns[ 0 ];
+            var defaultCampaigns = PersonalizationEngineUtil.GetDefaultCampaign( campaignTypeEnumList, numCampaigns );
 
-            StringContent restContent = new StringContent( JsonConvert.SerializeObject( campaignResult ), Encoding.UTF8, "application/json" );
+            StringContent restContent = new StringContent( JsonConvert.SerializeObject( defaultCampaigns ), Encoding.UTF8, "application/json" );
             return new HttpResponseMessage()
             {
                 Content = restContent


### PR DESCRIPTION
Updated GetRelevantCampaign to accept an optional count for how many campaigns to retrieve.

Updated GetDefaultCampaign to accept an optional count for how many campaigns to retrieve.

Updated Campaign REST Endpoints to allow /Campaign/ to be used to get either relevant campaigns OR default campaigns depending on whether a personId is provided.
