### PR TITLE
Updated the URL for editing a group member to use a lava variable.

### DIFF
--- a/RockWeb/Themes/church_ccv_External_v8/Assets/Lava/dashboard/toolbox/toolbox-group-members.lava
+++ b/RockWeb/Themes/church_ccv_External_v8/Assets/Lava/dashboard/toolbox/toolbox-group-members.lava
@@ -54,7 +54,7 @@
                             </div>
                             <div class="person-info">
                                 <div>
-                                    <a href="/toolbox/edit-group-member?GroupMemberId={{ member.Id }}&AdminPersonId={{ CurrentPerson.Id }}"> <h5>{{ member.Person.FullName }}</h5> </a> 
+                                    <a href="{{ editGroupMemberRoute }}?GroupMemberId={{ member.Id }}&AdminPersonId={{ CurrentPerson.Id }}"> <h5>{{ member.Person.FullName }}</h5> </a> 
                                 </div>
                                 {% unless member.GroupMemberStatus == 1 %}
                                     <p style="padding: 0;"><small>{{ member.GroupMemberStatus }}</small></p>


### PR DESCRIPTION
This allows the CCV Group toolbox to point to one edit page, and the Life Training toolbox to point to another.
