### PR TITLE
Fix User Login List block

### DIFF
--- a/RockWeb/Blocks/Security/UserLoginList.ascx.cs
+++ b/RockWeb/Blocks/Security/UserLoginList.ascx.cs
@@ -259,7 +259,7 @@ namespace RockWeb.Blocks.Security
 
                 // guard against invalid usernames
                 string newUserName = tbUserNameEdit.Text.Trim();
-                if ( UserLoginService.IsUsernameValid( tbUserNameEdit.Text ) )
+                if ( UserLoginService.IsUsernameValid( tbUserNameEdit.Text ) == false )
                 {
                     nbErrorMessage.NotificationBoxType = NotificationBoxType.Warning;
                     nbErrorMessage.Title = "Invalid User Name";


### PR DESCRIPTION
Throw an error if IsUsernameValid returns FALSE, not TRUE. Because I'…m an idiot.
-Fixes an issue preventing valid usernames from being saved on the profile page in Rock.
