### PR TITLE
Personalization Engine Date Fixes

### DIFF
--- a/RockWeb/Plugins/church_ccv/PersonalizationEngine/CampaignDetail.ascx.cs
+++ b/RockWeb/Plugins/church_ccv/PersonalizationEngine/CampaignDetail.ascx.cs
@@ -200,8 +200,8 @@ namespace RockWeb.Plugins.church_ccv.PersonalizationEngine
                 }
                 else
                 {
-                    campaign.StartDate = dtpStartDate.SelectedDate.Value;
-                    campaign.EndDate = dtpEndDate.SelectedDate;
+                    campaign.StartDate = dtpStartDate.SelectedDate.Value.Date;
+                    campaign.EndDate = dtpEndDate.SelectedDate.HasValue ? dtpEndDate.SelectedDate.Value.Date : new DateTime?( );
                 }
 
                 // now get the types this campaign is using, along with the actual values for each type

--- a/RockWeb/Plugins/church_ccv/PersonalizationEngine/Tester.ascx
+++ b/RockWeb/Plugins/church_ccv/PersonalizationEngine/Tester.ascx
@@ -17,10 +17,20 @@
                         </div>
                     </div>
                     <div class="row">
-                        <div class="col-md-3">
+                        <div class="col-sm-6">
                             <asp:Literal runat="server"><strong>Target Date</strong></asp:Literal>
                             <Rock:DatePicker runat="server" ClientIDMode="Static" ID="dtpTargetDate" AutoPostBack="true" OnTextChanged="dpTargetDate_TextChanged"/>
-                             
+                        </div>
+                    </div>
+                    <div class="row">
+                        <div class="col-sm-12">
+                            <br />
+                            <span>Campaign Start Date is inclusive, and End Date is exclusive.</span>
+                        </div>
+                    </div>
+                    <div class="row">
+                        <div class="col-sm-12">
+                            <span><strong>Example:</strong> Start: 6-1-19 End: 6-7-19 means it begins showing on 6-1-19, and 6-6-19 is the last day it shows.</span>
                         </div>
                     </div>
                 </div>
@@ -42,9 +52,10 @@
                 <Rock:Grid ID="gCampaigns" Title="Attached Campaigns" runat="server" DisplayType="Light" RowItemText="Campaign" AllowPaging="false">
                     <Columns>
                         <Rock:RockBoundField DataField="Name" HeaderText="Name" />
-                        <Rock:RockBoundField DataField="Description" HeaderText="Description" />
                         <Rock:RockBoundField DataField="Priority" HeaderText="Priority" />
                         <Rock:RockBoundField DataField="Type" HeaderText="Locations" />
+                        <Rock:RockBoundField DataField="StartDate" HeaderText="Start Date" SortExpression="StartDate" DataFormatString="{0:M/dd/yy}" />
+                        <Rock:RockBoundField DataField="EndDate" HeaderText="End Date" SortExpression="EndDate" DataFormatString="{0:M/dd/yy}"/>
                     </Columns>
                 </Rock:Grid>
             </div>

--- a/church.ccv.PersonalizationEngine/Data/PersonalizationEngineUtil.cs
+++ b/church.ccv.PersonalizationEngine/Data/PersonalizationEngineUtil.cs
@@ -124,6 +124,19 @@ namespace church.ccv.PersonalizationEngine.Data
         static List<Campaign> GetCampaigns( string campaignTypeList, DateTime? startDate = null, DateTime? endDate = null, bool isDefault = false )
         {
             // get all campaigns of the provided types, that fall within the requested date range
+
+            // truncate provided dates to only the date (this system doesn't support time for the expiration date/time)
+            if ( startDate.HasValue )
+            {
+                startDate = startDate.Value.Date;
+            }
+            if ( endDate.HasValue )
+            {
+                endDate = endDate.Value.Date;
+            }
+
+            // NOTE: Start Dates are inclusive; End Dates are EXCLUSIVE.
+            // Example: If a campaign is: 6-1-19 thru 6-7-19, it will BEGIN display on 6-1, and the LAST DAY it will display is 6-6.
             
             // Default campaigns are those that are NOT tied to a persona.
             // if isDefault is FALSE, then we get campaigns that ARE tied to personas
@@ -150,7 +163,8 @@ namespace church.ccv.PersonalizationEngine.Data
                                          .Where( c => startDate.HasValue == false || c.StartDate <= startDate.Value )
 
                                          // A campaign does NOT need to have an end date--so if it doesn't have one just take it
-                                         .Where( c => c.EndDate.HasValue == false || endDate.HasValue == false || c.EndDate >= endDate.Value )
+                                         // if it DOES, then it must be _AFTER_ the provided endDate. 
+                                         .Where( c => c.EndDate.HasValue == false || endDate.HasValue == false || c.EndDate > endDate.Value )
 
                                          // for each Campaign, see if any element of campaignTypeIds is contained in c.Type (the CSV)
                                          .Where( c => campaignTypes.Any( t => c.Type.Contains( t ) ) )
@@ -283,7 +297,7 @@ namespace church.ccv.PersonalizationEngine.Data
 
             // if no target date is passed in, use Now. (Target date is used generally for debugging a future time)
             if ( targetDate == null )
-                targetDate = DateTime.Now;
+                targetDate = DateTime.Now.Date;
 
             // guard against passing in <= 0 numbers
             numCampaigns = Math.Max( numCampaigns, 1 );


### PR DESCRIPTION
Updated the Personalization Engine to ignore the Time within a DateTime
Updated Campaigns so that the EndDate is EXCLUSIVE (won't show on the actual end date)
Added Start / End dates to the Tester, and added helper notes.
