### PR TITLE
Feature bt ma filter by capacity

### DIFF
--- a/church.ccv.CCVRest/MobileApp/Util/MAGroupService.cs
+++ b/church.ccv.CCVRest/MobileApp/Util/MAGroupService.cs
@@ -345,7 +345,7 @@ namespace church.ccv.CCVRest.MobileApp
                 return true;
             }
 
-            if( g.GroupCapacity <= g.Members.Count() )
+            if( g.GroupCapacity < g.Members.Count() )
             {
                 return true;
             }

--- a/church.ccv.MobileApp/Data/MobileAppUtil.cs
+++ b/church.ccv.MobileApp/Data/MobileAppUtil.cs
@@ -123,10 +123,7 @@ namespace church.ccv.MobileApp
                         groupResult.Filters = group.AttributeValues[ GroupFilters_Key ].Value;
                     }
 
-                    //if ( !GroupOverCapacity( group ) )
-                    //{
-                        resultGroups.Add( groupResult );
-                    //}
+                    resultGroups.Add( groupResult );
                     
                 }
             }

--- a/church.ccv.MobileApp/Data/MobileAppUtil.cs
+++ b/church.ccv.MobileApp/Data/MobileAppUtil.cs
@@ -67,7 +67,7 @@ namespace church.ccv.MobileApp
                 // Instantiate as IQueryable so we don't store in memory just yet.
                 IQueryable<Group> gQuery = groupService.Queryable( "Schedule,GroupLocations.Location" ).AsNoTracking();
 
-                FilterOverCapacity( gQuery );
+                gQuery = FilterOverCapacity( gQuery );
 
                 // get all groups of this group type that are either public, if publicOnly is true, or either if publicOnly is false
 
@@ -185,7 +185,7 @@ namespace church.ccv.MobileApp
 
         // Modify and return a Group Query to filter 
         // out any group that is at capacity.
-        public static IQueryable FilterOverCapacity( IQueryable<Group> gQuery)
+        public static IQueryable<Group> FilterOverCapacity( IQueryable<Group> gQuery)
         {
             return gQuery.Where( g => g.GroupCapacity == null || g.Members.Count() < g.GroupCapacity );
         }


### PR DESCRIPTION
Add's capacity filters for group search on mobile app.  

Current Mobile App:
Groups that are over capacity will no longer be returned with the search results.

New Mobile App: 
A new parameter, 'HasCapacity' has been added to the data structure.  If the group does not have capacity, this will be set to false, otherwise true.  