### PR TITLE
Bugfix bt lifetraining note by

### DIFF
--- a/Rock/Web/UI/Controls/NoteControl.cs
+++ b/Rock/Web/UI/Controls/NoteControl.cs
@@ -887,11 +887,6 @@ namespace Rock.Web.UI.Controls
 
                 note.NoteTypeId = NoteTypeId.Value;
 
-                if ( string.IsNullOrWhiteSpace( note.Caption ) )
-                {
-                    note.Caption = string.Empty;
-                }
-
                 note.Text = Text;
                 note.IsAlert = IsAlert;
                 note.IsPrivateNote = IsPrivate;

--- a/Rock/Web/UI/Controls/NoteControl.cs
+++ b/Rock/Web/UI/Controls/NoteControl.cs
@@ -778,7 +778,7 @@ namespace Rock.Web.UI.Controls
 
                     if ( IsPrivate )
                     {
-                        heading += "( Private Note )";
+                        heading += " ( Private Note )";
                     }
 
                     if ( !string.IsNullOrWhiteSpace( Caption ) )

--- a/Rock/Web/UI/Controls/NoteControl.cs
+++ b/Rock/Web/UI/Controls/NoteControl.cs
@@ -774,12 +774,20 @@ namespace Rock.Web.UI.Controls
                         }
                     }
 
-                    string heading = Caption;
-                    if ( string.IsNullOrWhiteSpace( Caption ) )
+                    string heading = CreatedByName;
+
+                    if ( IsPrivate )
                     {
-                        heading = CreatedByName;
+                        heading += "( Private Note )";
                     }
+
+                    if ( !string.IsNullOrWhiteSpace( Caption ) )
+                    {
+                        heading += " " + Caption + " ";
+                    }
+
                     writer.Write( heading.EncodeHtml() );
+
                     if ( CreatedDateTime.HasValue )
                     {
                         writer.Write( " " );
@@ -878,10 +886,12 @@ namespace Rock.Web.UI.Controls
                 }
 
                 note.NoteTypeId = NoteTypeId.Value;
+
                 if ( string.IsNullOrWhiteSpace( note.Caption ) )
                 {
-                    note.Caption = IsPrivate ? "You - Personal Note" : string.Empty;
+                    note.Caption = string.Empty;
                 }
+
                 note.Text = Text;
                 note.IsAlert = IsAlert;
                 note.IsPrivateNote = IsPrivate;


### PR DESCRIPTION
Removes using caption for the heading of the note.  Instead, if the IsPrivate Flag is set, "( Private Note )" will be added to the heading of the note.  

The new note heading format when using the Note List block will be "[CreatedByName] {If IsPrivate}( Private Note ){/if} [Caption]".